### PR TITLE
Add /index.js to @babel/runtime/regenerator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Patch
 
 - Also run GitHub Actions with Node.js v14.
+- Transform `@babel/runtime/regenerator` require or import specifiers to `@babel/runtime/regenerator/index.js`, via [#1](https://github.com/jaydenseric/babel-plugin-transform-runtime-file-extensions/pull/1).
 
 ## 1.0.0
 

--- a/index.js
+++ b/index.js
@@ -4,17 +4,15 @@
  * Checks if a specifier is an extensionless Babel runtime specifier. If so,
  * adds the extension.
  * @param {string} specifier Specifier to check.
- * @returns {boolean} Is the specifier an extensionless Babel runtime specifier.
  */
 function transform(specifier) {
   if (
     specifier.value.startsWith('@babel/runtime/helpers/') &&
     !specifier.value.endsWith('.js')
-  ) {
+  )
     specifier.value = `${specifier.value}.js`;
-  } else if (specifier.value === '@babel/runtime/regenerator') {
+  else if (specifier.value === '@babel/runtime/regenerator')
     specifier.value = `${specifier.value}/index.js`;
-  }
 }
 
 /**
@@ -32,9 +30,7 @@ module.exports = function babelPluginTransformRuntimeFileExtensions() {
       // Example ExportNamedDeclaration (unlikely to occur):
       //   export { default as _objectWithoutPropertiesLoose } from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
       'ImportDeclaration|ExportNamedDeclaration'(path) {
-        if (path.node.source) {
-          transform(path.node.source);
-        }
+        if (path.node.source) transform(path.node.source);
       },
 
       // Example CallExpression:
@@ -42,9 +38,8 @@ module.exports = function babelPluginTransformRuntimeFileExtensions() {
       CallExpression(path) {
         if (path.node.callee.name === 'require') {
           const [specifier] = path.node.arguments;
-          if (specifier && specifier.type === 'StringLiteral') {
+          if (specifier && specifier.type === 'StringLiteral')
             transform(specifier);
-          }
         }
       },
     },

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
 /**
- * Checks if a specifier is an extensionless Babel runtime specifier. If so,
- * adds the extension.
- * @param {string} specifier Specifier to check.
+ * Ensures a require or import string literal specifier has a file extension if
+ * it’s for the Babel runtime.
+ * @param {{value: string}} specifier Require or import string literal specifier.
  */
-function transform(specifier) {
+function fixBabelRuntimeSpecifier(specifier) {
   if (
     specifier.value.startsWith('@babel/runtime/helpers/') &&
     !specifier.value.endsWith('.js')
@@ -30,7 +30,7 @@ module.exports = function babelPluginTransformRuntimeFileExtensions() {
       // Example ExportNamedDeclaration (unlikely to occur):
       //   export { default as _objectWithoutPropertiesLoose } from "@babel/runtime/helpers/objectWithoutPropertiesLoose";
       'ImportDeclaration|ExportNamedDeclaration'(path) {
-        if (path.node.source) transform(path.node.source);
+        if (path.node.source) fixBabelRuntimeSpecifier(path.node.source);
       },
 
       // Example CallExpression:
@@ -39,7 +39,7 @@ module.exports = function babelPluginTransformRuntimeFileExtensions() {
         if (path.node.callee.name === 'require') {
           const [specifier] = path.node.arguments;
           if (specifier && specifier.type === 'StringLiteral')
-            transform(specifier);
+            fixBabelRuntimeSpecifier(specifier);
         }
       },
     },

--- a/test.js
+++ b/test.js
@@ -27,6 +27,26 @@ tests.add('Import from Babel runtime, with extension.', () => {
   );
 });
 
+tests.add('Import from Babel runtime regenerator, no extension.', () => {
+  strictEqual(
+    babel.transform(
+      'import _regeneratorRuntime from "@babel/runtime/regenerator";',
+      { plugins: [babelPluginTransformRuntimeFileExtensions] }
+    ).code,
+    'import _regeneratorRuntime from "@babel/runtime/regenerator/index.js";'
+  );
+});
+
+tests.add('Import from Babel runtime regenerator, with extension.', () => {
+  strictEqual(
+    babel.transform(
+      'import _regeneratorRuntime from "@babel/runtime/regenerator/index.js";',
+      { plugins: [babelPluginTransformRuntimeFileExtensions] }
+    ).code,
+    'import _regeneratorRuntime from "@babel/runtime/regenerator/index.js";'
+  );
+});
+
 tests.add('Import not from Babel runtime.', () => {
   strictEqual(
     babel.transform('import a from "a";', {
@@ -56,6 +76,26 @@ tests.add('Export from Babel runtime, with extension.', () => {
   );
 });
 
+tests.add('Export from Babel runtime regenerator, no extension.', () => {
+  strictEqual(
+    babel.transform(
+      'export { default as _regeneratorRuntime } from "@babel/runtime/regenerator";',
+      { plugins: [babelPluginTransformRuntimeFileExtensions] }
+    ).code,
+    'export { default as _regeneratorRuntime } from "@babel/runtime/regenerator/index.js";'
+  );
+});
+
+tests.add('Export from Babel runtime regenerator, with extension.', () => {
+  strictEqual(
+    babel.transform(
+      'export { default as _regeneratorRuntime } from "@babel/runtime/regenerator/index.js";',
+      { plugins: [babelPluginTransformRuntimeFileExtensions] }
+    ).code,
+    'export { default as _regeneratorRuntime } from "@babel/runtime/regenerator/index.js";'
+  );
+});
+
 tests.add('Export not from Babel runtime.', () => {
   strictEqual(
     babel.transform('export { default as a } from "a";', {
@@ -82,6 +122,24 @@ tests.add('Require from Babel runtime, with extension.', () => {
       { plugins: [babelPluginTransformRuntimeFileExtensions] }
     ).code,
     'require("@babel/runtime/helpers/objectWithoutPropertiesLoose.js");'
+  );
+});
+
+tests.add('Require from Babel runtime regenerator, no extension.', () => {
+  strictEqual(
+    babel.transform('require("@babel/runtime/regenerator");', {
+      plugins: [babelPluginTransformRuntimeFileExtensions],
+    }).code,
+    'require("@babel/runtime/regenerator/index.js");'
+  );
+});
+
+tests.add('Require from Babel runtime regenerator, with extension.', () => {
+  strictEqual(
+    babel.transform('require("@babel/runtime/regenerator/index.js");', {
+      plugins: [babelPluginTransformRuntimeFileExtensions],
+    }).code,
+    'require("@babel/runtime/regenerator/index.js");'
   );
 });
 


### PR DESCRIPTION
Hi! Thanks for this workaround plugin. I noticed that imports from `@babel/runtime/regenerator` would also need the file extensions. Unlike `runtime/helpers`, there's only `index.js`.